### PR TITLE
Fix duplicate file metadata

### DIFF
--- a/src/main/services/FileStorage.ts
+++ b/src/main/services/FileStorage.ts
@@ -72,7 +72,7 @@ class FileStorage {
           return {
             id,
             origin_name: file,
-            name: file + ext,
+            name: file,
             path: storedFilePath,
             created_at: storedStats.birthtime.toISOString(),
             size: storedStats.size,


### PR DESCRIPTION
## Summary
- fix duplicate file `name` when detecting uploaded duplicates

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9e19d0c8322857d0c678fb59972