### PR TITLE
Add reasoning export test

### DIFF
--- a/src/renderer/src/utils/__tests__/export.test.ts
+++ b/src/renderer/src/utils/__tests__/export.test.ts
@@ -344,5 +344,15 @@ describe('export', () => {
       expect(markdown).toContain('Single user query')
       expect(markdown.split('\n\n---\n\n').length).toBe(1)
     })
+
+    it('should include reasoning section when option is enabled', () => {
+      const msgWithReasoning = createMessage({ role: 'assistant', id: 'a_reason' }, [
+        { type: MessageBlockType.MAIN_TEXT, content: 'Answer with reasoning' },
+        { type: MessageBlockType.THINKING, content: 'Reasoning details' }
+      ])
+      const markdown = messagesToMarkdown([msgWithReasoning], true)
+      expect(markdown).toContain('<details')
+      expect(markdown).toContain('Reasoning details')
+    })
   })
 })


### PR DESCRIPTION
## Summary
- cover reasoning option in `messagesToMarkdown`

## Testing
- `yarn install` *(fails: RequestError 403)*
- `yarn test` *(fails: missing node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_683ffeb92c7c8322a1441fc2f022118e